### PR TITLE
Update heltec.h

### DIFF
--- a/src/heltec.h
+++ b/src/heltec.h
@@ -11,6 +11,7 @@
 
 #define DISPLAY_WIDTH 128
 #define DISPLAY_HEIGHT 32
+#define OLED_RST 16  //add this line for OLED_RST undefined error when compiling heltec.cpp in platformIO
 
 #endif
 


### PR DESCRIPTION
When I use vsCode+PlatformIO to compile the "helloWorld" oled example for 'wifi_kit_8' board, I met the error that saying the 'OLED_RST' undefined for compiling `heltec.cpp`. By adding line '#define OLED_RST 16', this error got fixed and compiling got succeeded. By the way, if the developer wants the `#ifdefined(WIFI_Kit_8)` work, one should add `build_flags = -D KIFI_Kit_8` in the `platformio.ino` file.